### PR TITLE
update macos x86 to 15

### DIFF
--- a/.github/workflows/macos-x86-64-build.yml
+++ b/.github/workflows/macos-x86-64-build.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     permissions:
       actions: write
     steps:


### PR DESCRIPTION
I'm getting warnings from github that macos-13 is deprecated and should be upgraded or kill. 

Not sure if you are getting it, but I was trying to found which repo was generating this warning, and I think is this one. (Hope that this works) 